### PR TITLE
Release Candidate v1.0.0-alpha.4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,11 @@ jobs:
         run: |
           TAG_VERSION="${GITHUB_REF_NAME#v}"
           GRADLE_VERSION=$(grep -E '^version = ' sdk/build.gradle.kts | head -1 | sed -E 's/.*"(.+)".*/\1/')
+          CORE_VERSION=$(grep -E '^version = ' core/build.gradle.kts | head -1 | sed -E 's/.*"(.+)".*/\1/')
+          if [ "$CORE_VERSION" != "$GRADLE_VERSION" ]; then
+            echo "::error::core version $CORE_VERSION does not match sdk version $GRADLE_VERSION"
+            exit 1
+          fi
           if [ "$TAG_VERSION" != "$GRADLE_VERSION" ]; then
             echo "::error::Tag $GITHUB_REF_NAME does not match Gradle version $GRADLE_VERSION"
             exit 1
@@ -54,4 +59,4 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_SIGNING_PASSWORD }}
-        run: ./gradlew build :sdk:publishAndReleaseToMavenCentral :spring:publishAndReleaseToMavenCentral --no-configuration-cache
+        run: ./gradlew build :core:publishAndReleaseToMavenCentral :sdk:publishAndReleaseToMavenCentral :spring:publishAndReleaseToMavenCentral --no-configuration-cache

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,6 +1,9 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     `java-library`
     id("com.diffplug.spotless") version "6.25.0"
+    id("com.vanniktech.maven.publish") version "0.30.0"
 }
 
 spotless {
@@ -14,7 +17,37 @@ spotless {
 }
 
 group = "com.nuntly"
-version = "1.0.0-alpha.3"
+version = "1.0.0-alpha.4"
+
+mavenPublishing {
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
+    signAllPublications()
+    coordinates("com.nuntly", "nuntly-java-core", version.toString())
+
+    pom {
+        name.set("Nuntly Java SDK Core")
+        description.set("HTTP client and shared infrastructure for the Nuntly Java SDK.")
+        url.set("https://nuntly.com")
+        licenses {
+            license {
+                name.set("MIT")
+                url.set("https://opensource.org/licenses/MIT")
+            }
+        }
+        developers {
+            developer {
+                id.set("nuntly")
+                name.set("Nuntly")
+                email.set("support@nuntly.com")
+            }
+        }
+        scm {
+            url.set("https://github.com/nuntly/nuntly-sdk-java")
+            connection.set("scm:git:git://github.com/nuntly/nuntly-sdk-java.git")
+            developerConnection.set("scm:git:ssh://github.com:nuntly/nuntly-sdk-java.git")
+        }
+    }
+}
 
 java {
     toolchain {

--- a/sdk/build.gradle.kts
+++ b/sdk/build.gradle.kts
@@ -17,7 +17,7 @@ spotless {
 }
 
 group = "com.nuntly"
-version = "1.0.0-alpha.3"
+version = "1.0.0-alpha.4"
 
 mavenPublishing {
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)

--- a/spring/build.gradle.kts
+++ b/spring/build.gradle.kts
@@ -17,7 +17,7 @@ spotless {
 }
 
 group = "com.nuntly"
-version = "1.0.0-alpha.3"
+version = "1.0.0-alpha.4"
 
 mavenPublishing {
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)


### PR DESCRIPTION
# Release Candidate v1.0.0-alpha.4

Java 21 SDK for Nuntly (`com.nuntly:nuntly-java`, `com.nuntly:nuntly-java-spring`).

## Next step

Merge this PR, then tag `v1.0.0-alpha.4` to trigger the release workflow.

---

Generated from source `e5d36bf7a23c`.